### PR TITLE
update mac homebrew cuda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ $ npm install hs-miner
 
 ``` bash
 $ brew install node git coreutils perl grep gnu-sed gawk python2
-$ brew cask install cuda
+$ brew tap caskroom/drivers
+$ brew cask install nvidia-cuda
 $ npm install hs-miner
 ```
 


### PR DESCRIPTION
The current instructions do not work. The ```cuda cask``` has been renamed. See [here](https://github.com/Homebrew/homebrew-cask/issues/38325).